### PR TITLE
remove unused readUtf8 in TProtocol.py

### DIFF
--- a/lib/py/src/protocol/TProtocol.py
+++ b/lib/py/src/protocol/TProtocol.py
@@ -184,9 +184,6 @@ class TProtocolBase(object):
     def readBinary(self):
         pass
 
-    def readUtf8(self):
-        return self.readString().decode('utf-8')
-
     def skip(self, ttype):
         if ttype == TType.BOOL:
             self.readBool()


### PR DESCRIPTION
Cleanup after https://github.com/apache/thrift/pull/3105

<!-- Explain the changes in the pull request below: -->

readUtf8 is not referenced anywhere in the code anymore

<!-- We recommend you review the checklist/tips before submitting a pull request. -->

- [ ] Did you create an [Apache Jira](https://issues.apache.org/jira/projects/THRIFT/issues/) ticket?  ([Request account here](https://selfserve.apache.org/jira-account.html), not required for trivial changes)
- [ ] If a ticket exists: Does your pull request title follow the pattern "THRIFT-NNNN: describe my issue"?
- [x] Did you squash your changes to a single commit?  (not required, but preferred)
- [x] Did you do your best to avoid breaking changes?  If one was needed, did you label the Jira ticket with "Breaking-Change"?
- [ ] If your change does not involve any code, include `[skip ci]` anywhere in the commit message to free up build resources.

<!--
  The Contributing Guide at:
  https://github.com/apache/thrift/blob/master/CONTRIBUTING.md
  has more details and tips for committing properly.
-->
